### PR TITLE
Refactor chat_with_repo modules

### DIFF
--- a/repo_agent/chat_with_repo/__init__.py
+++ b/repo_agent/chat_with_repo/__init__.py
@@ -1,3 +1,10 @@
-# repo_agent/chat_with_repo/__init__.py
+"""Entry points for the ``chat_with_repo`` package."""
 
-from .main import main
+
+def main() -> None:
+    """Run the interactive chat interface."""
+    from .main import main as _main
+
+    return _main()
+
+__all__ = ["main"]

--- a/repo_agent/chat_with_repo/data_access/__init__.py
+++ b/repo_agent/chat_with_repo/data_access/__init__.py
@@ -1,0 +1,6 @@
+"""Data access utilities for the chat_with_repo module."""
+
+from .json_handler import JsonFileProcessor
+from .text_analysis_tool import TextAnalysisTool
+
+__all__ = ["JsonFileProcessor", "TextAnalysisTool"]

--- a/repo_agent/chat_with_repo/data_access/json_handler.py
+++ b/repo_agent/chat_with_repo/data_access/json_handler.py
@@ -1,3 +1,5 @@
+"""Utilities for loading and searching project JSON data."""
+
 import json
 import sys
 

--- a/repo_agent/chat_with_repo/data_access/text_analysis_tool.py
+++ b/repo_agent/chat_with_repo/data_access/text_analysis_tool.py
@@ -1,7 +1,9 @@
+"""Lightweight NLP utilities used by the repository chat assistant."""
+
 from llama_index.core.llms.function_calling import FunctionCallingLLM
 from llama_index.llms.openai import OpenAI
 
-from repo_agent.chat_with_repo.json_handler import JsonFileProcessor
+from repo_agent.chat_with_repo.data_access.json_handler import JsonFileProcessor
 
 
 class TextAnalysisTool:

--- a/repo_agent/chat_with_repo/main.py
+++ b/repo_agent/chat_with_repo/main.py
@@ -1,6 +1,6 @@
 import time
 
-from repo_agent.chat_with_repo.gradio_interface import GradioInterface
+from repo_agent.chat_with_repo.ui.gradio_interface import GradioInterface
 from repo_agent.chat_with_repo.rag import RepoAssistant
 from repo_agent.log import logger
 from repo_agent.settings import SettingsManager

--- a/repo_agent/chat_with_repo/rag.py
+++ b/repo_agent/chat_with_repo/rag.py
@@ -2,15 +2,15 @@ import json
 
 from llama_index.llms.openai import OpenAI
 
-from repo_agent.chat_with_repo.json_handler import JsonFileProcessor
+from repo_agent.chat_with_repo.data_access.json_handler import JsonFileProcessor
 from repo_agent.chat_with_repo.prompt import (
     query_generation_template,
     rag_ar_template,
     rag_template,
     relevance_ranking_chat_template,
 )
-from repo_agent.chat_with_repo.text_analysis_tool import TextAnalysisTool
-from repo_agent.chat_with_repo.vector_store_manager import VectorStoreManager
+from repo_agent.chat_with_repo.data_access.text_analysis_tool import TextAnalysisTool
+from repo_agent.chat_with_repo.vector_store.vector_store_manager import VectorStoreManager
 from repo_agent.log import logger
 
 

--- a/repo_agent/chat_with_repo/ui/__init__.py
+++ b/repo_agent/chat_with_repo/ui/__init__.py
@@ -1,0 +1,5 @@
+"""User interface components for interacting with the assistant."""
+
+from .gradio_interface import GradioInterface
+
+__all__ = ["GradioInterface"]

--- a/repo_agent/chat_with_repo/ui/gradio_interface.py
+++ b/repo_agent/chat_with_repo/ui/gradio_interface.py
@@ -1,3 +1,5 @@
+"""Gradio-based user interface for interacting with the assistant."""
+
 import gradio as gr
 import markdown
 

--- a/repo_agent/chat_with_repo/vector_store/__init__.py
+++ b/repo_agent/chat_with_repo/vector_store/__init__.py
@@ -1,0 +1,5 @@
+"""Vector store management utilities for the chat_with_repo module."""
+
+from .vector_store_manager import VectorStoreManager
+
+__all__ = ["VectorStoreManager"]

--- a/repo_agent/chat_with_repo/vector_store/vector_store_manager.py
+++ b/repo_agent/chat_with_repo/vector_store/vector_store_manager.py
@@ -1,3 +1,5 @@
+"""Abstraction layer over the Chroma vector store."""
+
 import chromadb
 from llama_index.core import (
     Document,

--- a/tests/test_json_handler.py
+++ b/tests/test_json_handler.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import mock_open, patch
 
-from repo_agent.chat_with_repo.json_handler import (
+from repo_agent.chat_with_repo.data_access.json_handler import (
     JsonFileProcessor,  # Adjust the import according to your project structure
 )
 


### PR DESCRIPTION
## Summary
- create `data_access`, `vector_store`, and `ui` subpackages
- move helper modules into the new packages
- add documentation comments for each subpackage and module
- update imports to new locations
- adjust tests to use the new package paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'git')*